### PR TITLE
[DRAFT][luci/service] Support CircleOutputDummy as reshape's shape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -134,3 +134,67 @@ TEST(ShapeRuleTest, reshape_should_infer)
   ASSERT_TRUE(output_shape.dim(1).known());
   ASSERT_EQ(4, output_shape.dim(1).value());
 }
+
+TEST(ShapeRuleTest, reshape_by_dummy_static)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_dummy = g->nodes()->create<luci::CircleOutputDummy>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 3, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_dummy->dtype(loco::DataType::S32);
+  shape_dummy->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_dummy);
+  node_reshape->newShape()->rank(2);
+  node_reshape->newShape()->dim(0) = 6;
+  node_reshape->newShape()->dim(1) = 4;
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
+
+  ASSERT_EQ(2, output_shape.rank());
+  ASSERT_TRUE(output_shape.dim(0).known());
+  ASSERT_TRUE(output_shape.dim(1).known());
+  ASSERT_EQ(6, output_shape.dim(0).value());
+  ASSERT_EQ(4, output_shape.dim(1).value());
+}
+
+TEST(ShapeRuleTest, reshape_by_dummy_dynamic)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_dummy = g->nodes()->create<luci::CircleOutputDummy>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 3, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_dummy->dtype(loco::DataType::S32);
+  shape_dummy->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_dummy);
+  node_reshape->newShape()->rank(2);
+  node_reshape->newShape()->dim(0) = -1;
+  node_reshape->newShape()->dim(1) = 4;
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
+
+  ASSERT_EQ(2, output_shape.rank());
+  ASSERT_TRUE(output_shape.dim(0).known());
+  ASSERT_TRUE(output_shape.dim(1).known());
+  ASSERT_EQ(6, output_shape.dim(0).value());
+  ASSERT_EQ(4, output_shape.dim(1).value());
+}


### PR DESCRIPTION
This commit supports `CircleOutputDummy` as the `shape` for the reshape operation.

- This is the 4th step in supporting dynamic shape inference for the reshape operation.

Draft: https://github.com/Samsung/ONE/pull/13999
Related: https://github.com/Samsung/ONE/issues/13927

ONE-DCO-1.0-Signed-off-by: Jongwon Yang <yjw963@gmail.com>